### PR TITLE
Bump commons-fileupload from 1.1.1 to 1.3.3 in /assembly

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.1.1</version>
+      <version>1.3.3</version>
     </dependency>
     
     


### PR DESCRIPTION
Bumps commons-fileupload from 1.1.1 to 1.3.3.

Signed-off-by: dependabot[bot] <support@github.com>