### PR TITLE
Bump commons-collections from 2.1 to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-digester</groupId>


### PR DESCRIPTION
Bumps commons-collections from 2.1 to 3.2.2.

---
updated-dependencies:
- dependency-name: commons-collections:commons-collections
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>