### PR TITLE
Bump commons-beanutils from 1.8.0 to 1.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.8.0</version>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                <groupId>commons-codec</groupId>


### PR DESCRIPTION
Bumps commons-beanutils from 1.8.0 to 1.9.4.

---
updated-dependencies:
- dependency-name: commons-beanutils:commons-beanutils
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>